### PR TITLE
Update dependencies and squelch warnings

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -2,8 +2,8 @@ var gulp = require('gulp');
 var babel = require('gulp-babel');
 var concat = require('gulp-concat');
 var uglify = require('gulp-uglify');
-var minifyHtml = require('gulp-minify-html');
-var minifyCss = require('gulp-minify-css');
+var minifyHtml = require('gulp-htmlmin');
+var minifyCss = require('gulp-cssnano');
 
 gulp.task('static', function() {
   return gulp.src(['./static/**/*', './static/**/.*'])

--- a/package.json
+++ b/package.json
@@ -1,12 +1,17 @@
 {
-  "name": "admin.bergems.org",
+  "name": "dispatch.bergems.org",
   "version": "1.0.0",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mcems/dispatch.git"
+  },
   "dependencies": {
     "gulp": "^3.9.0",
     "gulp-babel": "^5.2.1",
     "gulp-concat": "^2.6.0",
-    "gulp-minify-css": "^1.2.1",
-    "gulp-minify-html": "^1.0.4",
+    "gulp-cssnano": "^2.1.0",
+    "gulp-htmlmin": "^1.3.0",
     "gulp-uglify": "^1.4.1"
   }
 }


### PR DESCRIPTION
The CSS and HTML minifiers that were being used have been deprecated, so
this replaces them with their recommended successors. Additionally, npm
install was generating warnings because the package.json did not have
license or repository fields. This has been rectified.
